### PR TITLE
Update v0.0.1 build number and hash

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,12 @@ package:
 
 source:
   url: https://github.com/bcdev/xarray-enmap/archive/v{{ version }}.tar.gz
-  sha256: 37c342085041b1243cb92cdca2efa2de3caf466e8152b26acb6037274d193c55
+  sha256: 2b550e45a14fde6dc8f17bda748d95f76e14a4aaa187b3449cbb9de1a8e24eb1
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
The GitHub v0.0.1 was moved to point to another commit, so we need a rebuild to reflect this.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
